### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Jon Black <jon@humblecoder.com>
 maintainer=Jon Black <jon@humblecoder.com>
 sentence=A library for interacting with the steem web socket api
 paragraph=Currently supports `get_block` only.
-category=uncategorized
+category=Other
 url=https://github.com/jonblack/steemduino
 architectures=avr


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'uncategorized' in library steemduino is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format